### PR TITLE
Fixed Error on Typescript for Extract Values function. 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ export declare interface Fields {
 
 export declare function useValidation(initialValue: any, validationFn: ((v: any) => boolean) | ((v: any) => Promise<boolean>), config?: FieldConfig): Field;
 
-export declare function extractValues(fields: Fields): object;
+export declare function extractValues(fields: Fields): object | any;
 
 export declare function setValues(fields: Fields, values: object): void;
 


### PR DESCRIPTION
**What was the Error?**
I was getting an error of property does not exists on typescript when building a react app. 

```
const data = extractValues(applyForm)
if (data.phoneNumber!= data.phoneNumber) {
     setMismatchPhoneNumberError(true)
}
```